### PR TITLE
feat: per-particle t_offset for independent simulation timelines

### DIFF
--- a/sfparticles/cpu.py
+++ b/sfparticles/cpu.py
@@ -89,15 +89,17 @@ def photon_recoil(ux, uy, uz, inv_gamma, event, photon_delta, N, to_be_pruned):
 
 @njit(
     void(
-        *[float64[:]]*12, 
-        float64[:], boolean[:], 
+        *[float64[:]]*15, 
+        boolean[:], 
         int64[:], float64[:], int64, int64,
     ), 
     parallel=True, cache=False
 )
 def create_photon(
     x_src, y_src, z_src, ux_src, uy_src, uz_src,
+    t_offset_src,
     x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+    t_offset_dst,
     inv_gamma_dst, photon_to_be_pruned,
     event_index, photon_delta, N_buffered, N_photon,
 ):
@@ -107,6 +109,7 @@ def create_photon(
         x_dst[idx_dst] = x_src[idx_src]
         y_dst[idx_dst] = y_src[idx_src]
         z_dst[idx_dst] = z_src[idx_src]
+        t_offset_dst[idx_dst] = t_offset_src[idx_src]
         
         ux_dst[idx_dst] = photon_delta[idx_src] * ux_src[idx_src]
         uy_dst[idx_dst] = photon_delta[idx_src] * uy_src[idx_src]
@@ -119,10 +122,10 @@ def create_photon(
 
 @njit(
     void(
-        *[float64[:]]*6, 
+        *[float64[:]]*7, 
         boolean[:], 
-        *[float64[:]]*6, 
-        float64[:], boolean[:], 
+        *[float64[:]]*8, 
+        boolean[:], 
         int64[:], float64[:], int64, int64,
         boolean,
     ), 
@@ -130,8 +133,10 @@ def create_photon(
 )
 def create_pair(
     x_src, y_src, z_src, ux_src, uy_src, uz_src,
+    t_offset_src,
     photon_to_be_pruned,
     x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+    t_offset_dst,
     inv_gamma_dst, pair_to_be_pruned,
     event_index, pair_delta, N_buffered, N_pair,
     inverse_delta,
@@ -172,6 +177,7 @@ def create_pair(
         x_dst[idx_dst] = x_src[idx_src]
         y_dst[idx_dst] = y_src[idx_src]
         z_dst[idx_dst] = z_src[idx_src]
+        t_offset_dst[idx_dst] = t_offset_src[idx_src]
         
         delta = pair_delta[idx_src]
         if inverse_delta: 

--- a/sfparticles/fields.py
+++ b/sfparticles/fields.py
@@ -29,21 +29,23 @@ class Fields(object):
             else:
                 field_func_inline = cuda.jit(field_func)
             @cuda.jit
-            def field_function(x, y, z, t, N, to_be_pruned, Ex, Ey, Ez, Bx, By, Bz):
+            def field_function(x, y, z, t, t_offset, N, to_be_pruned, Ex, Ey, Ez, Bx, By, Bz):
                 ip = cuda.grid(1)
                 if ip < N and ~to_be_pruned[ip]:
-                    Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip] = field_func_inline(x[ip], y[ip], z[ip], t)
+                    t_eff = t + t_offset[ip]
+                    Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip] = field_func_inline(x[ip], y[ip], z[ip], t_eff)
         else:
             if isinstance(field_func, CPUDispatcher):
                 field_func_inline = field_func
             else:
                 field_func_inline = njit(field_func, cache=False)
             @njit(parallel=True, cache=False)
-            def field_function(x, y, z, t, N, to_be_pruned, Ex, Ey, Ez, Bx, By, Bz):
+            def field_function(x, y, z, t, t_offset, N, to_be_pruned, Ex, Ey, Ez, Bx, By, Bz):
                 for ip in prange(N):
                     if to_be_pruned[ip]:
                         continue
-                    Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip] = field_func_inline(x[ip], y[ip], z[ip], t)
+                    t_eff = t + t_offset[ip]
+                    Ex[ip], Ey[ip], Ez[ip], Bx[ip], By[ip], Bz[ip] = field_func_inline(x[ip], y[ip], z[ip], t_eff)
 
         self.field_func_inline = field_func_inline
         self.field_func = field_function

--- a/sfparticles/gpu.py
+++ b/sfparticles/gpu.py
@@ -140,7 +140,9 @@ if _use_gpu:
     @cuda.jit
     def create_photon_kernal(
         x_src, y_src, z_src, ux_src, uy_src, uz_src,
+        t_offset_src,
         x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+        t_offset_dst,
         inv_gamma_dst, photon_to_be_pruned,
         event_index, photon_delta, N_buffered, N_photon,
     ):
@@ -151,6 +153,7 @@ if _use_gpu:
             x_dst[idx_dst] = x_src[idx_src]
             y_dst[idx_dst] = y_src[idx_src]
             z_dst[idx_dst] = z_src[idx_src]
+            t_offset_dst[idx_dst] = t_offset_src[idx_src]
             
             ux_dst[idx_dst] = photon_delta[idx_src] * ux_src[idx_src]
             uy_dst[idx_dst] = photon_delta[idx_src] * uy_src[idx_src]
@@ -161,14 +164,18 @@ if _use_gpu:
             photon_to_be_pruned[idx_dst] = False
     def create_photon(
         x_src, y_src, z_src, ux_src, uy_src, uz_src,
+        t_offset_src,
         x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+        t_offset_dst,
         inv_gamma_dst, photon_to_be_pruned,
         event_index, photon_delta, N_buffered, N_photon,
     ):
         bpg = int(N_photon/tpb) + 1
         create_photon_kernal[bpg, tpb](
             x_src, y_src, z_src, ux_src, uy_src, uz_src,
+            t_offset_src,
             x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+            t_offset_dst,
             inv_gamma_dst, photon_to_be_pruned,
             event_index, photon_delta, N_buffered, N_photon,
         )
@@ -176,8 +183,10 @@ if _use_gpu:
     @cuda.jit
     def create_pair_kernal(
         x_src, y_src, z_src, ux_src, uy_src, uz_src,
+        t_offset_src,
         photon_to_be_pruned,
         x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+        t_offset_dst,
         inv_gamma_dst, pair_to_be_pruned,
         event_index, pair_delta, N_buffered, N_pair,
         inverse_delta,
@@ -189,6 +198,7 @@ if _use_gpu:
             x_dst[idx_dst] = x_src[idx_src]
             y_dst[idx_dst] = y_src[idx_src]
             z_dst[idx_dst] = z_src[idx_src]
+            t_offset_dst[idx_dst] = t_offset_src[idx_src]
             
             delta = pair_delta[idx_src]
             if inverse_delta: 
@@ -207,8 +217,10 @@ if _use_gpu:
             photon_to_be_pruned[idx_src] = True
     def create_pair(
         x_src, y_src, z_src, ux_src, uy_src, uz_src,
+        t_offset_src,
         photon_to_be_pruned,
         x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+        t_offset_dst,
         inv_gamma_dst, pair_to_be_pruned,
         event_index, pair_delta, N_buffered, N_pair,
         inverse_delta,
@@ -216,8 +228,10 @@ if _use_gpu:
         bpg = int(N_pair/tpb) + 1
         create_pair_kernal[bpg, tpb](
             x_src, y_src, z_src, ux_src, uy_src, uz_src,
+            t_offset_src,
             photon_to_be_pruned,
             x_dst, y_dst, z_dst, ux_dst, uy_dst, uz_dst,
+            t_offset_dst,
             inv_gamma_dst, pair_to_be_pruned,
             event_index, pair_delta, N_buffered, N_pair,
             inverse_delta,

--- a/sfparticles/particles.py
+++ b/sfparticles/particles.py
@@ -101,14 +101,17 @@ class Particles(object):
             self.ux = np.zeros(N)
             self.uy = np.zeros(N)
             self.uz = np.zeros(N)
-                
+            self.t_offset = np.zeros(N)
 
         if props:
-            assert len(props) == 6, 'given properties must has length of 6'
+            assert len(props) in (6, 7), 'given properties must has length of 6 or 7'
 
-            props_ = prepare_props(props, N)
+            props_ = prepare_props(props[:6], N)
 
             self.x, self.y, self.z, self.ux, self.uy, self.uz = props_
+
+            if len(props) == 7:
+                self.t_offset = prepare_props((props[6],), N)[0]
 
         # position, momentum and spin vectors
         self.attrs += ['x', 'y', 'z', 'ux', 'uy', 'uz']
@@ -136,6 +139,10 @@ class Particles(object):
         self.Bx = np.zeros(N)
         self.By = np.zeros(N)
         self.attrs += ['Ex', 'Ey', 'Ez', 'Bx', 'By', 'Bz']
+
+        if not hasattr(self, 't_offset'):
+            self.t_offset = np.zeros(N)
+        self.attrs += ['t_offset']
 
         # buffer
         self.N_buffered = N
@@ -311,14 +318,14 @@ class Particles(object):
             from .gpu import tpb
             bpg = int(self.N_buffered / tpb) + 1
             fields.field_func[bpg, tpb](
-                self.x, self.y, self.z, t, self.N_buffered, self._to_be_pruned,
-                self.Ex, self.Ey, self.Ez, 
+                self.x, self.y, self.z, t, self.t_offset, self.N_buffered, self._to_be_pruned,
+                self.Ex, self.Ey, self.Ez,
                 self.Bx, self.By, self.Bz
             )
         else:
             fields.field_func(
-                self.x, self.y, self.z, t, self.N_buffered, self._to_be_pruned,
-                self.Ex, self.Ey, self.Ez, 
+                self.x, self.y, self.z, t, self.t_offset, self.N_buffered, self._to_be_pruned,
+                self.Ex, self.Ey, self.Ez,
                 self.Bx, self.By, self.Bz
             )
 
@@ -419,7 +426,9 @@ class Particles(object):
             
             create_photon(
                 self.x, self.y, self.z, self.ux, self.uy, self.uz,
+                self.t_offset,
                 pho.x, pho.y, pho.z, pho.ux, pho.uy, pho.uz,
+                pho.t_offset,
                 pho.inv_gamma, pho._to_be_pruned,
                 event_index, self.photon_delta, pho.N_buffered, N_photon,
             )
@@ -454,16 +463,20 @@ class Particles(object):
             pos._extend(N_pair)
             create_pair(
                 self.x, self.y, self.z, self.ux, self.uy, self.uz,
+                self.t_offset,
                 self._to_be_pruned,
                 ele.x, ele.y, ele.z, ele.ux, ele.uy, ele.uz,
+                ele.t_offset,
                 ele.inv_gamma, ele._to_be_pruned,
                 event_index, self.pair_delta, ele.N_buffered, N_pair,
                 inverse_delta=False,
             )
             create_pair(
                 self.x, self.y, self.z, self.ux, self.uy, self.uz,
+                self.t_offset,
                 self._to_be_pruned,
                 pos.x, pos.y, pos.z, pos.ux, pos.uy, pos.uz,
+                pos.t_offset,
                 pos.inv_gamma, pos._to_be_pruned,
                 event_index, self.pair_delta, pos.N_buffered, N_pair,
                 inverse_delta=True,
@@ -562,9 +575,12 @@ class SpinParticles(Particles):
             self.sy = np.zeros(N)
             self.sz = np.zeros(N)
         if props:
-            assert len(props) == 9, 'given properties must has length of 9'
-            super().__init__(name, q, m, N, props[:6], RR, ae, push)
-            props_ = prepare_props(props[6:])
+            assert len(props) in (9, 10), 'given properties must has length of 9 or 10'
+            if len(props) == 9:
+                super().__init__(name, q, m, N, props[:6], RR, push)
+            else:
+                super().__init__(name, q, m, N, props[:6] + (props[9],), RR, push)
+            props_ = prepare_props(props[6:9], N)
 
             self.sx, self.sy, self.sz = props_
 

--- a/tests/test_t_offset.py
+++ b/tests/test_t_offset.py
@@ -1,0 +1,96 @@
+import unittest
+import numpy as np
+
+from sfparticles import Particles, SpinParticles, Fields, RadiationReactionType
+
+
+class TestTOffset(unittest.TestCase):
+
+    def test_t_offset_default(self):
+        """Backward compatibility: no t_offset provided defaults to zeros."""
+        p = Particles('e', q=-1, m=1, N=10, props=(np.zeros(10),)*6)
+        self.assertTrue('t_offset' in p.attrs)
+        self.assertEqual(p.t_offset.shape, (10,))
+        self.assertTrue(np.all(p.t_offset == 0))
+
+    def test_t_offset_from_props(self):
+        """7-element props for Particles includes t_offset."""
+        to = np.array([0.0, 1.0, 2.0] + [0.0]*7)
+        p = Particles('e', q=-1, m=1, N=10, props=(np.zeros(10),)*6 + (to,))
+        self.assertTrue(np.allclose(p.t_offset, to))
+
+    def test_t_offset_spinparticles(self):
+        """10-element props for SpinParticles includes t_offset."""
+        to = np.array([0.0, 1.0] + [0.0]*8)
+        p = SpinParticles('e', q=-1, m=1, N=10, props=(np.zeros(10),)*9 + (to,))
+        self.assertTrue(np.allclose(p.t_offset, to))
+        # Also verify backward compat with 9 elements
+        p2 = SpinParticles('e', q=-1, m=1, N=10, props=(np.zeros(10),)*9)
+        self.assertTrue(np.all(p2.t_offset == 0))
+
+    def test_t_offset_field_evaluation(self):
+        """Field eval uses t + t_offset for each particle."""
+        def field_func(x, y, z, t):
+            return (t, 0, 0, 0, 0, 0)
+        fields = Fields(field_func)
+        to = np.array([0.0, 1.0, 2.0])
+        p = Particles('e', q=-1, m=1, N=3, props=(np.zeros(3),)*6 + (to,))
+        p._eval_field(fields, 1.0)
+        self.assertTrue(np.allclose(p.Ex, [1.0, 2.0, 3.0]))  # t=1.0 + t_offset
+
+    def test_t_offset_buffer_extend(self):
+        """_extend preserves t_offset values for existing particles."""
+        to = np.array([1.0, 2.0, 3.0])
+        p = Particles('e', q=-1, m=1, N=3, props=(np.zeros(3),)*6 + (to,))
+        p._extend(10)
+        self.assertTrue(np.allclose(p.t_offset[:3], to))
+
+    def test_t_offset_buffer_prune(self):
+        """_prune preserves t_offset for remaining particles."""
+        to = np.array([1.0, 2.0, 3.0])
+        p = Particles('e', q=-1, m=1, N=3, props=(np.zeros(3),)*6 + (to,))
+        p._to_be_pruned[1] = True
+        p._prune()
+        self.assertTrue(np.allclose(p.t_offset, [1.0, 3.0]))
+
+    def test_t_offset_inheritance_photon(self):
+        """Photon creation inherits t_offset from parent electron."""
+        ele = Particles(
+            'ele', q=-1, m=1, N=1,
+            props=(np.zeros(1), np.zeros(1), np.zeros(1), np.ones(1), np.zeros(1), np.zeros(1)),
+            RR=RadiationReactionType.PHOTON
+        )
+        to = np.array([5.0])
+        ele.t_offset = to.copy()
+        pho = Particles('pho', q=0, m=0)
+        ele.set_photon(pho)
+        # Manually trigger an event
+        ele.event[0] = True
+        ele.photon_delta[0] = 0.5
+        ele._create_photon(pho)
+        self.assertEqual(pho.N_buffered, 1)
+        self.assertTrue(np.allclose(pho.t_offset[:1], to))
+
+    def test_t_offset_inheritance_pair(self):
+        """Pair creation inherits t_offset from parent photon."""
+        pho = Particles(
+            'pho', q=0, m=0, N=1,
+            props=(np.zeros(1), np.zeros(1), np.zeros(1), np.ones(1), np.zeros(1), np.zeros(1)),
+        )
+        to = np.array([7.0])
+        pho.t_offset = to.copy()
+        ele = Particles('ele', q=-1, m=1)
+        pos = Particles('pos', q=1, m=1)
+        pho.set_pair(ele, pos)
+        # Manually trigger an event
+        pho.event[0] = True
+        pho.pair_delta[0] = 0.5
+        pho._create_pair(ele, pos)
+        self.assertEqual(ele.N_buffered, 1)
+        self.assertEqual(pos.N_buffered, 1)
+        self.assertTrue(np.allclose(ele.t_offset[:1], to))
+        self.assertTrue(np.allclose(pos.t_offset[:1], to))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Add per-particle `t_offset` support so each particle evaluates electromagnetic fields at `t + t_offset`, enabling independent simulation timelines. Cascade-created particles (photons, electron-positron pairs) inherit their parent's `t_offset`.

## Changes

### Particles (`sfparticles/particles.py`)
- Add `self.t_offset` array initialized to zeros for all particles
- Add `'t_offset'` to `self.attrs` so GPU transfer and buffer resize/prune operations automatically include it
- Extend `props` parsing: optional 7th element `(x, y, z, ux, uy, uz, t_offset)` for `Particles`
- Extend `SpinParticles` `props` parsing: optional 10th element `(x, y, z, ux, uy, uz, sx, sy, sz, t_offset)`
- `_eval_field` passes `self.t_offset` to field evaluation kernels
- `_create_photon` and `_create_pair` pass parent's `t_offset` to creation functions

### Fields (`sfparticles/fields.py`)
- CPU (`@njit`) and GPU (`@cuda.jit`) wrapper kernels now accept `t_offset` array
- Inside kernel loop: compute `t_eff = t + t_offset[ip]` and pass to user `field_func(x, y, z, t_eff)`
- User-facing `field_func` signature unchanged: `(x, y, z, t) -> (Ex, Ey, Ez, Bx, By, Bz)`

### Backends (`sfparticles/cpu.py`, `sfparticles/gpu.py`)
- `create_photon` / `create_pair` signatures extended with `t_offset_src` and `t_offset_dst`
- New particles copy parent's `t_offset` value
- GPU kernels mirror CPU logic exactly

### Tests (`tests/test_t_offset.py`)
- 8 new unit tests covering:
  - Default `t_offset` (backward compatibility)
  - `t_offset` from 7-element `Particles` props
  - `t_offset` from 10-element `SpinParticles` props
  - Field evaluation uses `t + t_offset` per particle
  - Buffer `_extend` preserves `t_offset`
  - Buffer `_prune` preserves `t_offset`
  - Photon creation inherits `t_offset`
  - Pair creation inherits `t_offset`

## Backward Compatibility

- Existing code without `t_offset` behaves identically (defaults to all zeros)
- All 27 existing tests pass without modification
- No changes to QED modules, simulation timestep logic, or `__init__.py` exports

## Test Results

```
Ran 35 tests in ~28s
OK
```